### PR TITLE
Fix bug where Paratest throws exception if class has all tests excluded.

### DIFF
--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -216,6 +216,8 @@ class Reader extends MetaProvider
 
         if ($node !== false) {
             $this->suites[] = TestSuite::suiteFromNode($node);
+        } else {
+            $this->suites[] = TestSuite::suiteFromArray(self::$defaultSuite);
         }
     }
 }

--- a/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
+++ b/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
@@ -203,16 +203,6 @@ class ResultPrinter
                 $test->getStdout()
             ));
         }
-        if (!$reader->hasResults()) {
-            throw new \RuntimeException(sprintf(
-                "The process: %s\nLog file \"%s\" is empty.\n" .
-                "This means a PHPUnit process was unable to run \"%s\"\n" .
-                "Maybe there is more than one class in this file.",
-                $test->getLastCommand(),
-                $test->getTempFile(),
-                $test->getPath()
-            ));
-        }
         $this->results->addReader($reader);
         $this->processReaderFeedback($reader, $test->getTestCount());
         $this->printTestWarnings($test);


### PR DESCRIPTION
## Description
Paratest will throw an exception if a class is included that has all of its tests excluded. This is going to happen when we run Liturgy tests because we are trying to exclude the IzzyResource package tests that are used by OCP only via the '@group ocpOnly' annotation.
